### PR TITLE
Fix issues with premoving castling and shako pawn double step

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -218,7 +218,7 @@ export function selectSquare(state: State, key: cg.Key, force?: boolean): void {
 export function setSelected(state: State, key: cg.Key): void {
   state.selected = key;
   if (isPremovable(state, key)) {
-    state.premovable.dests = premove(state.pieces, key, state.premovable.castle, state.geometry, state.variant);
+    state.premovable.dests = premove(state.pieces, key, state.premovable.castle, state.geometry, state.variant, state.chess960);
   }
   else {
     state.premovable.dests = undefined;
@@ -279,7 +279,7 @@ export function isPredroppable(state: State): boolean {
 function canPremove(state: State, orig: cg.Key, dest: cg.Key): boolean {
   return orig !== dest &&
   isPremovable(state, orig) &&
-  containsX(premove(state.pieces, orig, state.premovable.castle, state.geometry, state.variant), dest);
+  containsX(premove(state.pieces, orig, state.premovable.castle, state.geometry, state.variant, state.chess960), dest);
 }
 
 /*

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,7 @@ export interface Config {
   };
   geometry?: cg.Geometry; // dim3x4 | dim5x5 | dim7x7 | dim8x8 | dim9x9 | dim10x8 | dim9x10 | dim10x10
   variant?: cg.Variant;
+	chess960? : boolean;
   notation?: cg.Notation;
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -112,6 +112,7 @@ export interface State {
   dimensions: cg.BoardDimensions, // number of lines and ranks of the board {width: 10, height: 8}
   geometry: cg.Geometry, // dim8x8 | dim9x9 | dim10x8 | dim9x10
   variant: cg.Variant,
+  chess960: Boolean,
   notation: cg.Notation,
 }
 
@@ -199,6 +200,7 @@ export function defaults(): Partial<State> {
     dimensions: {width: 8, height: 8},
     geometry: cg.Geometry.dim8x8,
     variant: 'chess',
+    chess960: false,
     notation: cg.Notation.DEFAULT,
   };
 }


### PR DESCRIPTION
https://github.com/gbtami/pychess-variants/issues/613
While investigating premoving castling in Shako I found a few other issues and decided are related enough to fix all in one pull request:

- In any 8x8 variant with at least one standard army it was possible to premove both king two squares towards the rook and king takes rook, but only king two squares would actually be played if legal after opponent moves
- In any 8x8 960 if king and rook happened to be on their standard squares there were again two ways to premove, but this time only king takes rook would actually fire
- In Capablanca/Capahouse the only way to premove was king takes rook which never fired
- In Capablanca960/Capahouse960 if king happened to be on the e file and rook on a or h it was possible to premove king two squares towards the rook which again never fired
- Red was allowed to premove castling in Synochess

I added missing premoves for Shako and restricted allowed premoves for listed variants to only those which can actually fire. 